### PR TITLE
Linkify URLs missed by preprocessor

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,9 @@ else {
 
 Mehdown.usernameRegExp = /(^|[^@\w])@(\w{1,15})\b/g;
 
+// Examples of what this will match: http://jsbin.com/eqocuh/552/edit
+Mehdown.urlRegExp = /((?:(?:[A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+|(?:[A-Za-z0-9\.\-]+\.(?:com|org|net|gov|edu|co\.uk|io)))(?:(?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)(?:#?[\b\w\/!]+)(?:[\-\.\!\/\w]*))?)/g;
+
 Mehdown.parse = function(text) {
     text = text.trim();
 
@@ -31,6 +34,33 @@ Mehdown.parse = function(text) {
 
     // Strikethrough
     text = text.replace(/~~(.*)~~/g, '<s>$1</s>');
+
+    // Any URLs that are not already anchored
+    text = text.replace(Mehdown.urlRegExp, function() {
+        var domain = arguments[1];
+        var href = (domain.indexOf('http') < 0) ? 'http://' + domain : domain;
+        var preceding = text.substring(0, arguments[2]);
+        var insideTagAttrRegex = /<(?!\/)[^>]+(?!>)$/g;
+        var insideAnchorTagRegex = /<a[^>]*>(?!<\/a>)$/g;
+
+        // inside tag attr or anchor tag, abort
+        if (preceding.match(insideTagAttrRegex) || preceding.match(insideAnchorTagRegex)) {
+            return domain;
+        }
+
+        // don't use http protocol on email adresses
+        if (domain.indexOf('@') >= 0) {
+            var parts = domain.split('@');
+            if (parts[1].match(Mehdown.urlRegExp)) {
+                href = 'mailto:' + domain;
+            } else {
+                // this is a wierd something@something-no-tld that the regex thinks is a url, abort
+                return domain;
+            }
+        }
+
+        return '<a href="' + href + '">' + domain + '</a>';
+    });
 
     // Spoilers
     text = text.replace(/\[spoiler\](.*?)\[\/spoiler\]/gi, Mehdown.spoiler('$1'));

--- a/test/test.js
+++ b/test/test.js
@@ -50,6 +50,43 @@ describe('anchors', function() {
     });
 });
 
+describe('scheme-less domains', function() {
+    it('simple domain', function() {
+        var text = mehdown.parse('<p>stuff google.com more stuff</p>');
+        assert.equal(text, '<p>stuff <a rel="nofollow" target="_blank" href="http://google.com">google.com</a> more stuff</p>');
+    });
+
+    it('domain with path', function() {
+        var text = mehdown.parse('<p>mediocre.com/forum/topics/american-parties</p>');
+        assert.equal(text, '<p><a href="http://mediocre.com/forum/topics/american-parties">mediocre.com/forum/topics/american-parties</a></p>');
+    });
+
+    it('domain with query string', function() {
+        var text = mehdown.parse('<p>google.com/search?q=domain</p>');
+        assert.equal(text, '<p><a rel="nofollow" target="_blank" href="http://google.com/search?q=domain">google.com/search?q=domain</a></p>');
+    });
+
+    it('already linked domain', function() {
+        var text = mehdown.parse('<p><a href="http://example.com">http://example.com</a> and example.com</p>');
+        assert.equal(text, '<p><a rel="nofollow" target="_blank" href="http://example.com">http://example.com</a> and <a rel="nofollow" target="_blank" href="http://example.com">example.com</a></p>');
+    });
+
+    it('already linked domain with additional anchor text', function() {
+        var text = mehdown.parse('<p><a href="http://example.com">example.com is the coolest site</a></p>');
+        assert.equal(text, '<p><a rel="nofollow" target="_blank" href="http://example.com">example.com is the coolest site</a></p>');
+    });
+
+    it('domain is in tag attribute', function() {
+        var text = mehdown.parse('<p><a href="http://example.com" title="Go To Example.com">example.com</a></p>');
+        assert.equal(text, '<p><a rel="nofollow" target="_blank" href="http://example.com" title="Go To Example.com">example.com</a></p>');
+    });
+
+    it('email address', function() {
+        var text = mehdown.parse('<p>email me at whatever@somewhere.com if you are not a meanie.</p>');
+        assert.equal(text, '<p>email me at <a rel="nofollow" target="_blank" href="mailto:whatever@somewhere.com">whatever@somewhere.com</a> if you are not a meanie.</p>');
+    });
+});
+
 describe('images', function() {
     it('.jpg', function() {
         var text = mehdown.parse('<p><a href="http://i.imgur.com/9oiY1aO.jpg">http://i.imgur.com/9oiY1aO.jpg</a></p>');


### PR DESCRIPTION
i.e. scheme-less domains and email addresses

This was very complicated and probably not worth doing, but once I
started I was unable to stop.

Closes #11 

Ideally, the way to solve this would have been to move the pre-processor dependency to Mehdown, and have all apps that use Mehdown use only Mehdown and not whatever is processing Markdown first. Then Mehdown would have access to the raw text, and could potentially modify that before converting the Markdown to HTML. Then Mehdown could process all the URLs first, and it wouldn't have to check if it's inside an anchor or tag attribute.
