### PR TITLE
Render images with direct links to the images' source.

### DIFF
--- a/lib/plugins/images.js
+++ b/lib/plugins/images.js
@@ -13,18 +13,28 @@ module.exports = function(md) {
 
         if (hrefIndex !== -1) {
             var nextToken = tokens[idx + 1];
-            var uri = url.parse(token.attrs[hrefIndex][1]);
 
-            if (nextToken && nextToken.content === decodeURI(uri.href)) {
-                if (uri && uri.pathname) {
-                    var filename = uri.pathname.split('/').pop();
+            if (nextToken && nextToken.content) {
+                var content = nextToken.content;
+
+                var uri = url.parse(token.attrs[hrefIndex][1]);
+                var imageUri = url.parse(content);
+
+                if (imageUri && imageUri.pathname) {
+                    var filename = imageUri.pathname.split('/').pop();
                     var extension = filename.toLowerCase().split('.').pop();
 
                     if (extension && imageFileExtensions.indexOf(extension) !== -1) {
                         tokens[idx + 1].content = '';
                         tokens[idx + 2].hidden = true;
 
-                        return `<a href="${uri.href}" target="_blank"><img src="${uri.href}" /></a>`;
+                        // user wants the image to render as a link to something other than the image's source
+                        if (uri.href !== imageUri.href) {
+                          return `<a href="${uri.href}" target="_blank"><img src="${imageUri.href}" /></a>`;
+                        } else {
+                          // will render the image as a link to the image's source
+                          return `<a href="${imageUri.href}" target="_blank"><img src="${imageUri.href}" /></a>`;
+                        }
                     }
                 }
             }

--- a/lib/plugins/images.js
+++ b/lib/plugins/images.js
@@ -24,7 +24,7 @@ module.exports = function(md) {
                         tokens[idx + 1].content = '';
                         tokens[idx + 2].hidden = true;
 
-                        return `<img src="${uri.href}" />`;
+                        return `<a href="${uri.href}"><img src="${uri.href}" /></a>`;
                     }
                 }
             }

--- a/lib/plugins/images.js
+++ b/lib/plugins/images.js
@@ -24,7 +24,7 @@ module.exports = function(md) {
                         tokens[idx + 1].content = '';
                         tokens[idx + 2].hidden = true;
 
-                        return `<a href="${uri.href}"><img src="${uri.href}" /></a>`;
+                        return `<a href="${uri.href}" target="_blank"><img src="${uri.href}" /></a>`;
                     }
                 }
             }

--- a/test/fixtures/mehdown.html
+++ b/test/fixtures/mehdown.html
@@ -2,7 +2,7 @@
 <p>The Markdown parser used on the forums at <a href="http://meh.com">meh.com</a>.</p>
 <h2 id="adds-the-following-features-to-markdown">Adds the following features to Markdown:</h2>
 <p>Converts URL-like text to links: <a href="https://meh.com">https://meh.com</a><br />
-Converts image URLs to images: <img height="128" src="https://res.cloudinary.com/mediocre/image/upload/Meh36Faces128px_01_t366di.png" width="128" /><br />
+Converts image URLs to images: <a href="https://res.cloudinary.com/mediocre/image/upload/Meh36Faces128px_01_t366di.png"><img height="128" src="https://res.cloudinary.com/mediocre/image/upload/Meh36Faces128px_01_t366di.png" width="128" /></a><br />
 Optionally detects image sizes.<br />
 External links open in a new browser tab/window: <a href="https://www.woot.com" rel="nofollow" target="_blank">https://www.woot.com</a><br />
 Automatic detection of <code>@usernames</code>: <a href="https://meh.com/@shawn">@shawn</a><br />
@@ -20,7 +20,7 @@ Better linebreak/newline support.</p>
 </ul>
 <h2 id="supports-turning-urls-from-many-popular-sites-into-html-embeds">Supports turning URLs from many popular sites into HTML embeds:</h2>
 <p>Image URLs are converted to images.<br />
-<img height="128" src="https://res.cloudinary.com/mediocre/image/upload/Meh36Faces128px_01_t366di.png" width="128" /></p>
+<a href="https://res.cloudinary.com/mediocre/image/upload/Meh36Faces128px_01_t366di.png"><img height="128" src="https://res.cloudinary.com/mediocre/image/upload/Meh36Faces128px_01_t366di.png" width="128" /></a></p>
 <p>imgur GIFV URLs are converted to high quality looping GIF videos.<br />
 <div class="imgur-gifv"><video autoplay loop muted><source type="video/webm" src="https://i.imgur.com/zvATqgs.webm" /><source type="video/mp4" src="https://i.imgur.com/zvATqgs.mp4" /></video></div></p>
 <p>Kickstarter URLs are converted to campaign previews.<br />

--- a/test/fixtures/mehdown.html
+++ b/test/fixtures/mehdown.html
@@ -2,7 +2,7 @@
 <p>The Markdown parser used on the forums at <a href="http://meh.com">meh.com</a>.</p>
 <h2 id="adds-the-following-features-to-markdown">Adds the following features to Markdown:</h2>
 <p>Converts URL-like text to links: <a href="https://meh.com">https://meh.com</a><br />
-Converts image URLs to images: <a href="https://res.cloudinary.com/mediocre/image/upload/Meh36Faces128px_01_t366di.png"><img height="128" src="https://res.cloudinary.com/mediocre/image/upload/Meh36Faces128px_01_t366di.png" width="128" /></a><br />
+Converts image URLs to images: <a href="https://res.cloudinary.com/mediocre/image/upload/Meh36Faces128px_01_t366di.png" target="_blank"><img height="128" src="https://res.cloudinary.com/mediocre/image/upload/Meh36Faces128px_01_t366di.png" width="128" /></a><br />
 Optionally detects image sizes.<br />
 External links open in a new browser tab/window: <a href="https://www.woot.com" rel="nofollow" target="_blank">https://www.woot.com</a><br />
 Automatic detection of <code>@usernames</code>: <a href="https://meh.com/@shawn">@shawn</a><br />
@@ -20,7 +20,7 @@ Better linebreak/newline support.</p>
 </ul>
 <h2 id="supports-turning-urls-from-many-popular-sites-into-html-embeds">Supports turning URLs from many popular sites into HTML embeds:</h2>
 <p>Image URLs are converted to images.<br />
-<a href="https://res.cloudinary.com/mediocre/image/upload/Meh36Faces128px_01_t366di.png"><img height="128" src="https://res.cloudinary.com/mediocre/image/upload/Meh36Faces128px_01_t366di.png" width="128" /></a></p>
+<a href="https://res.cloudinary.com/mediocre/image/upload/Meh36Faces128px_01_t366di.png" target="_blank"><img height="128" src="https://res.cloudinary.com/mediocre/image/upload/Meh36Faces128px_01_t366di.png" width="128" /></a></p>
 <p>imgur GIFV URLs are converted to high quality looping GIF videos.<br />
 <div class="imgur-gifv"><video autoplay loop muted><source type="video/webm" src="https://i.imgur.com/zvATqgs.webm" /><source type="video/mp4" src="https://i.imgur.com/zvATqgs.mp4" /></video></div></p>
 <p>Kickstarter URLs are converted to campaign previews.<br />

--- a/test/index.js
+++ b/test/index.js
@@ -478,37 +478,47 @@ describe('detect image sizes', function() {
     });
 
     it('scheme relative broken image html', function(done) {
-        mehdown.render('//example.com/404.png', { detectImageSizes: true }, function(err, html) {
-            assert.equal(html, '<p><img src="//example.com/404.png" /></p>');
+        const image = '//example.com/404.png';
+
+        mehdown.render(image, { detectImageSizes: true }, function(err, html) {
+            assert.equal(html, `<p><a href="${image}"><img src="${image}" /></a></p>`);
             done();
         });
     });
 
     it('image from editor', function(done) {
-        mehdown.render('![enter image description here][1]\r\n\r\n  [1]: https://res.cloudinary.com/mediocre/image/upload/kekjvvhpkxh0v8x9o6u7.png "optional title"', { detectImageSizes: true }, function(err, html) {
-            assert.equal(html, '<p><img height="528" src="https://res.cloudinary.com/mediocre/image/upload/kekjvvhpkxh0v8x9o6u7.png" width="528" alt="enter image description here" title="optional title" /></p>');
+        const image = 'https://res.cloudinary.com/mediocre/image/upload/kekjvvhpkxh0v8x9o6u7.png';
+
+        mehdown.render(`![enter image description here][1]\r\n\r\n  [1]: ${image} "optional title"`, { detectImageSizes: true }, function(err, html) {
+            assert.equal(html, `<p><img height="528" src="${image}" width="528" alt="enter image description here" title="optional title" /></p>`);
             done();
         });
     });
 
     it('image html', function(done) {
-        mehdown.render('https://res.cloudinary.com/mediocre/image/upload/kekjvvhpkxh0v8x9o6u7.png', { detectImageSizes: true }, function(err, html) {
-            assert.equal(html, '<p><img height="528" src="https://res.cloudinary.com/mediocre/image/upload/kekjvvhpkxh0v8x9o6u7.png" width="528" /></p>');
+        const image = 'https://res.cloudinary.com/mediocre/image/upload/kekjvvhpkxh0v8x9o6u7.png';
+
+        mehdown.render(image, { detectImageSizes: true }, function(err, html) {
+            assert.equal(html, `<p><a href="${image}"><img height="528" src="${image}" width="528" /></a></p>`);
             done();
         });
     });
 
     it('scheme relative image html', function(done) {
-        mehdown.render('//res.cloudinary.com/mediocre/image/upload/kekjvvhpkxh0v8x9o6u7.png', { detectImageSizes: true }, function(err, html) {
-            assert.equal(html, '<p><img height="528" src="//res.cloudinary.com/mediocre/image/upload/kekjvvhpkxh0v8x9o6u7.png" width="528" /></p>');
+        const image = '//res.cloudinary.com/mediocre/image/upload/kekjvvhpkxh0v8x9o6u7.png';
+
+        mehdown.render(image, { detectImageSizes: true }, function(err, html) {
+            assert.equal(html, `<p><a href="${image}"><img height="528" src="${image}" width="528" /></a></p>`);
             done();
         });
     });
 
     // https://github.com/mediocre/forum-service/issues/64
     it('BUG: Cannot read property "height" of undefined', function(done) {
-        mehdown.render('jealous-dusty-magic http://cl.ly/image/0w251W2U1f1Q/Screen%20Shot%202014-06-16%20at%201.26.25%20PM.png @katylava says makes her think of fantasia', { detectImageSizes: true }, function(err, html) {
-            assert.equal(html, '<p>jealous-dusty-magic <img src="http://cl.ly/image/0w251W2U1f1Q/Screen%20Shot%202014-06-16%20at%201.26.25%20PM.png" /> <a href="/@katylava">@katylava</a> says makes her think of fantasia</p>');
+        const image = 'http://cl.ly/image/0w251W2U1f1Q/Screen%20Shot%202014-06-16%20at%201.26.25%20PM.png';
+
+        mehdown.render(`jealous-dusty-magic ${image} @katylava says makes her think of fantasia`, { detectImageSizes: true }, function(err, html) {
+            assert.equal(html, `<p>jealous-dusty-magic <a href="${image}"><img src="${image}" /></a> <a href="/@katylava">@katylava</a> says makes her think of fantasia</p>`);
             done();
         });
     });

--- a/test/index.js
+++ b/test/index.js
@@ -447,24 +447,32 @@ describe('commands', function() {
 
 describe('detect image sizes', function() {
     it('images', function(done) {
-        mehdown.render('https://res.cloudinary.com/mediocre/image/upload/kekjvvhpkxh0v8x9o6u7.png https://i.imgur.com/8peBgQn.png https://res.cloudinary.com/mediocre/image/upload/kekjvvhpkxh0v8x9o6u7.png', { detectImageSizes: true }, function(err, html) {
-            assert.equal(html, '<p><img height="528" src="https://res.cloudinary.com/mediocre/image/upload/kekjvvhpkxh0v8x9o6u7.png" width="528" /> <img height="250" src="https://i.imgur.com/8peBgQn.png" width="300" /> <img height="528" src="https://res.cloudinary.com/mediocre/image/upload/kekjvvhpkxh0v8x9o6u7.png" width="528" /></p>');
+        const image1 = 'https://res.cloudinary.com/mediocre/image/upload/kekjvvhpkxh0v8x9o6u7.png';
+        const image2 = 'https://i.imgur.com/8peBgQn.png';
+        const image3 = 'https://res.cloudinary.com/mediocre/image/upload/kekjvvhpkxh0v8x9o6u7.png';
+
+        mehdown.render(`${image1} ${image2} ${image3}`, { detectImageSizes: true }, function(err, html) {
+            assert.equal(html, `<p><a href="${image1}"><img height="528" src="${image1}" width="528" /></a> <a href="${image2}"><img height="250" src="${image2}" width="300" /></a> <a href="${image3}"><img height="528" src="${image3}" width="528" /></a></p>`);
             done();
         });
     });
 
     it('broken image', function(done) {
+        const image = 'http://example.com/404.png';
+
         this.timeout(10000);
 
-        mehdown.render('http://example.com/404.png', { detectImageSizes: true }, function(err, html) {
-            assert.equal(html, '<p><img src="http://example.com/404.png" /></p>');
+        mehdown.render(image, { detectImageSizes: true }, function(err, html) {
+            assert.equal(html, `<p><a href="${image}"><img src="${image}" /></a></p>`);
             done();
         });
     });
 
     it('broken image html', function(done) {
-        mehdown.render('http://example.com/404.png', { detectImageSizes: true }, function(err, html) {
-            assert.equal(html, '<p><img src="http://example.com/404.png" /></p>');
+        const image = 'http://example.com/404.png';
+
+        mehdown.render(image, { detectImageSizes: true }, function(err, html) {
+            assert.equal(html, `<p><a href="${image}"><img src="http://example.com/404.png" /></a></p>`);
             done();
         });
     });

--- a/test/index.js
+++ b/test/index.js
@@ -452,7 +452,7 @@ describe('detect image sizes', function() {
         const image3 = 'https://res.cloudinary.com/mediocre/image/upload/kekjvvhpkxh0v8x9o6u7.png';
 
         mehdown.render(`${image1} ${image2} ${image3}`, { detectImageSizes: true }, function(err, html) {
-            assert.equal(html, `<p><a href="${image1}"><img height="528" src="${image1}" width="528" /></a> <a href="${image2}"><img height="250" src="${image2}" width="300" /></a> <a href="${image3}"><img height="528" src="${image3}" width="528" /></a></p>`);
+            assert.equal(html, `<p><a href="${image1}" target="_blank"><img height="528" src="${image1}" width="528" /></a> <a href="${image2}" target="_blank"><img height="250" src="${image2}" width="300" /></a> <a href="${image3}" target="_blank"><img height="528" src="${image3}" width="528" /></a></p>`);
             done();
         });
     });
@@ -463,7 +463,7 @@ describe('detect image sizes', function() {
         this.timeout(10000);
 
         mehdown.render(image, { detectImageSizes: true }, function(err, html) {
-            assert.equal(html, `<p><a href="${image}"><img src="${image}" /></a></p>`);
+            assert.equal(html, `<p><a href="${image}" target="_blank"><img src="${image}" /></a></p>`);
             done();
         });
     });
@@ -472,7 +472,7 @@ describe('detect image sizes', function() {
         const image = 'http://example.com/404.png';
 
         mehdown.render(image, { detectImageSizes: true }, function(err, html) {
-            assert.equal(html, `<p><a href="${image}"><img src="http://example.com/404.png" /></a></p>`);
+            assert.equal(html, `<p><a href="${image}" target="_blank"><img src="http://example.com/404.png" /></a></p>`);
             done();
         });
     });
@@ -481,7 +481,7 @@ describe('detect image sizes', function() {
         const image = '//example.com/404.png';
 
         mehdown.render(image, { detectImageSizes: true }, function(err, html) {
-            assert.equal(html, `<p><a href="${image}"><img src="${image}" /></a></p>`);
+            assert.equal(html, `<p><a href="${image}" target="_blank"><img src="${image}" /></a></p>`);
             done();
         });
     });
@@ -499,7 +499,7 @@ describe('detect image sizes', function() {
         const image = 'https://res.cloudinary.com/mediocre/image/upload/kekjvvhpkxh0v8x9o6u7.png';
 
         mehdown.render(image, { detectImageSizes: true }, function(err, html) {
-            assert.equal(html, `<p><a href="${image}"><img height="528" src="${image}" width="528" /></a></p>`);
+            assert.equal(html, `<p><a href="${image}" target="_blank"><img height="528" src="${image}" width="528" /></a></p>`);
             done();
         });
     });
@@ -508,7 +508,7 @@ describe('detect image sizes', function() {
         const image = '//res.cloudinary.com/mediocre/image/upload/kekjvvhpkxh0v8x9o6u7.png';
 
         mehdown.render(image, { detectImageSizes: true }, function(err, html) {
-            assert.equal(html, `<p><a href="${image}"><img height="528" src="${image}" width="528" /></a></p>`);
+            assert.equal(html, `<p><a href="${image}" target="_blank"><img height="528" src="${image}" width="528" /></a></p>`);
             done();
         });
     });
@@ -518,7 +518,7 @@ describe('detect image sizes', function() {
         const image = 'http://cl.ly/image/0w251W2U1f1Q/Screen%20Shot%202014-06-16%20at%201.26.25%20PM.png';
 
         mehdown.render(`jealous-dusty-magic ${image} @katylava says makes her think of fantasia`, { detectImageSizes: true }, function(err, html) {
-            assert.equal(html, `<p>jealous-dusty-magic <a href="${image}"><img src="${image}" /></a> <a href="/@katylava">@katylava</a> says makes her think of fantasia</p>`);
+            assert.equal(html, `<p>jealous-dusty-magic <a href="${image}" target="_blank"><img src="${image}" /></a> <a href="/@katylava">@katylava</a> says makes her think of fantasia</p>`);
             done();
         });
     });

--- a/test/plugins/images.js
+++ b/test/plugins/images.js
@@ -84,4 +84,32 @@ describe('images', function() {
             done();
         });
     });
+
+    it('should render links to full size images when using Markdown inline syntax', function(done) {
+        mehdown.render('![Alt text](/path/to/img.jpg)', function(err, html) {
+            assert.equal(html, '<p><a href="/path/to/img.jpg" target="_blank"><img src="/path/to/img.jpg" alt="Alt text" /></a></p>');
+            done();
+        });
+    });
+
+    it('should render links to full size images when using Markdown inline syntax (with optional title)', function(done) {
+        mehdown.render('![Alt text](/path/to/img.jpg "Optional title")', function(err, html) {
+            assert.equal(html, '<p><a href="/path/to/img.jpg" target="_blank"><img src="/path/to/img.jpg" alt="Alt text" title="Optional title" /></a></p>');
+            done();
+        });
+    });
+
+    it('should render links to full size images when using Markdown reference syntax', function(done) {
+        mehdown.render('![Alt text][id]\n\n  [id]: url/to/image', function(err, html) {
+            assert.equal(html, '<p><a href="url/to/image" target="_blank"><img src="url/to/image" alt="Alt text" /></a></p>');
+            done();
+        });
+    });
+
+    it('should render links to full size images when using Markdown reference syntax (with optional title)', function(done) {
+        mehdown.render('![Alt text][id]\n\n  [id]: url/to/image  "Optional title attribute"', function(err, html) {
+            assert.equal(html, '<p><a href="url/to/image" target="_blank"><img src="url/to/image" alt="Alt text" title="Optional title attribute" /></a></p>');
+            done();
+        });
+    });
 });

--- a/test/plugins/images.js
+++ b/test/plugins/images.js
@@ -7,7 +7,7 @@ describe('images', function() {
         const image = 'http://example.com/image.jpeg';
 
         mehdown.render(image, function(err, html) {
-            assert.equal(html, `<p><a href="${image}"><img src="${image}" /></a></p>`);
+            assert.equal(html, `<p><a href="${image}" target="_blank"><img src="${image}" /></a></p>`);
             done();
         });
     });
@@ -16,7 +16,7 @@ describe('images', function() {
         const image = 'http://i.imgur.com/9oiY1aO.jpg';
 
         mehdown.render(image, function(err, html) {
-            assert.equal(html, `<p><a href="${image}"><img src="${image}" /></a></p>`);
+            assert.equal(html, `<p><a href="${image}" target="_blank"><img src="${image}" /></a></p>`);
             done();
         });
     });
@@ -25,7 +25,7 @@ describe('images', function() {
         const image = 'http://www.bubblews.com/assets/images/news/225123606_1387763263.gif';
 
         mehdown.render(image, function(err, html) {
-            assert.equal(html, `<p><a href="${image}"><img src="${image}" /></a></p>`);
+            assert.equal(html, `<p><a href="${image}" target="_blank"><img src="${image}" /></a></p>`);
             done();
         });
     });
@@ -34,7 +34,7 @@ describe('images', function() {
         const image = 'http://fc09.deviantart.net/fs44/f/2009/067/a/a/Green_Humming_Bird_PNG_by_pixievamp_stock.png';
 
         mehdown.render(image, function(err, html) {
-            assert.equal(html, `<p><a href="${image}"><img src="${image}" /></a></p>`);
+            assert.equal(html, `<p><a href="${image}" target="_blank"><img src="${image}" /></a></p>`);
             done();
         });
     });
@@ -43,7 +43,7 @@ describe('images', function() {
         const image = 'http://images.nationalgeographic.com/wpf/media-live/photos/000/770/cache/payunia-volcano-argentina_77070_990x742.jpg?01AD=3jGr9FxQ0BANJabwfZqq7ejovySQ1dQw8kO0oygkZlKrsJUzb-jUb7Q&01RI=1E4070A575D8186&01NA=na';
 
         mehdown.render(image, function(err, html) {
-            assert.equal(html, `<p><a href="${image}"><img src="${image}" /></a></p>`);
+            assert.equal(html, `<p><a href="${image}" target="_blank"><img src="${image}" /></a></p>`);
             done();
         });
     });
@@ -52,7 +52,7 @@ describe('images', function() {
         const image = 'http://izaak.jellinek.com/tuxes/images/big%20tux.png';
 
         mehdown.render(image, function(err, html) {
-            assert.equal(html, `<p><a href="${image}"><img src="${image}" /></a></p>`);
+            assert.equal(html, `<p><a href="${image}" target="_blank"><img src="${image}" /></a></p>`);
             done();
         });
     });
@@ -61,7 +61,7 @@ describe('images', function() {
         const image = 'http://cl.ly/image/0w251W2U1f1Q/Screen%20Shot%202014-06-16%20at%201.26.25%20PM.png';
 
         mehdown.render(image, function(err, html) {
-            assert.equal(html, `<p><a href="${image}"><img src="${image}" /></a></p>`);
+            assert.equal(html, `<p><a href="${image}" target="_blank"><img src="${image}" /></a></p>`);
             done();
         });
     });

--- a/test/plugins/images.js
+++ b/test/plugins/images.js
@@ -4,57 +4,73 @@ const mehdown = require('../../lib');
 
 describe('images', function() {
     it('.jpeg', function(done) {
-        mehdown.render('http://example.com/image.jpeg', function(err, html) {
-            assert.equal(html, '<p><img src="http://example.com/image.jpeg" /></p>');
+        const image = 'http://example.com/image.jpeg';
+
+        mehdown.render(image, function(err, html) {
+            assert.equal(html, `<p><a href="${image}"><img src="${image}" /></a></p>`);
             done();
         });
     });
 
     it('.jpg', function(done) {
-        mehdown.render('http://i.imgur.com/9oiY1aO.jpg', function(err, html) {
-            assert.equal(html, '<p><img src="http://i.imgur.com/9oiY1aO.jpg" /></p>');
+        const image = 'http://i.imgur.com/9oiY1aO.jpg';
+
+        mehdown.render(image, function(err, html) {
+            assert.equal(html, `<p><a href="${image}"><img src="${image}" /></a></p>`);
             done();
         });
     });
 
     it('.gif', function(done) {
-        mehdown.render('http://www.bubblews.com/assets/images/news/225123606_1387763263.gif', function(err, html) {
-            assert.equal(html, '<p><img src="http://www.bubblews.com/assets/images/news/225123606_1387763263.gif" /></p>');
+        const image = 'http://www.bubblews.com/assets/images/news/225123606_1387763263.gif';
+
+        mehdown.render(image, function(err, html) {
+            assert.equal(html, `<p><a href="${image}"><img src="${image}" /></a></p>`);
             done();
         });
     });
 
     it('.png', function(done) {
-        mehdown.render('http://fc09.deviantart.net/fs44/f/2009/067/a/a/Green_Humming_Bird_PNG_by_pixievamp_stock.png', function(err, html) {
-            assert.equal(html, '<p><img src="http://fc09.deviantart.net/fs44/f/2009/067/a/a/Green_Humming_Bird_PNG_by_pixievamp_stock.png" /></p>');
+        const image = 'http://fc09.deviantart.net/fs44/f/2009/067/a/a/Green_Humming_Bird_PNG_by_pixievamp_stock.png';
+
+        mehdown.render(image, function(err, html) {
+            assert.equal(html, `<p><a href="${image}"><img src="${image}" /></a></p>`);
             done();
         });
     });
 
     it('.jpg with long url and query string', function(done) {
-        mehdown.render('http://images.nationalgeographic.com/wpf/media-live/photos/000/770/cache/payunia-volcano-argentina_77070_990x742.jpg?01AD=3jGr9FxQ0BANJabwfZqq7ejovySQ1dQw8kO0oygkZlKrsJUzb-jUb7Q&01RI=1E4070A575D8186&01NA=na', function(err, html) {
-            assert.equal(html, '<p><img src="http://images.nationalgeographic.com/wpf/media-live/photos/000/770/cache/payunia-volcano-argentina_77070_990x742.jpg?01AD=3jGr9FxQ0BANJabwfZqq7ejovySQ1dQw8kO0oygkZlKrsJUzb-jUb7Q&01RI=1E4070A575D8186&01NA=na" /></p>');
+        const image = 'http://images.nationalgeographic.com/wpf/media-live/photos/000/770/cache/payunia-volcano-argentina_77070_990x742.jpg?01AD=3jGr9FxQ0BANJabwfZqq7ejovySQ1dQw8kO0oygkZlKrsJUzb-jUb7Q&01RI=1E4070A575D8186&01NA=na';
+
+        mehdown.render(image, function(err, html) {
+            assert.equal(html, `<p><a href="${image}"><img src="${image}" /></a></p>`);
             done();
         });
     });
 
     it('.png with %20 (space) in url', function(done) {
-        mehdown.render('http://izaak.jellinek.com/tuxes/images/big%20tux.png', function(err, html) {
-            assert.equal(html, '<p><img src="http://izaak.jellinek.com/tuxes/images/big%20tux.png" /></p>');
+        const image = 'http://izaak.jellinek.com/tuxes/images/big%20tux.png';
+
+        mehdown.render(image, function(err, html) {
+            assert.equal(html, `<p><a href="${image}"><img src="${image}" /></a></p>`);
             done();
         });
     });
 
     it('http://cl.ly/image/0w251W2U1f1Q/Screen%20Shot%202014-06-16%20at%201.26.25%20PM.png', function(done) {
-        mehdown.render('http://cl.ly/image/0w251W2U1f1Q/Screen%20Shot%202014-06-16%20at%201.26.25%20PM.png', function(err, html) {
-            assert.equal(html, '<p><img src="http://cl.ly/image/0w251W2U1f1Q/Screen%20Shot%202014-06-16%20at%201.26.25%20PM.png" /></p>');
+        const image = 'http://cl.ly/image/0w251W2U1f1Q/Screen%20Shot%202014-06-16%20at%201.26.25%20PM.png';
+
+        mehdown.render(image, function(err, html) {
+            assert.equal(html, `<p><a href="${image}"><img src="${image}" /></a></p>`);
             done();
         });
     });
 
     it('should not render image tags for image URLs in Markdown URL syntax', function(done) {
-        mehdown.render('[Fold out back](https://res.cloudinary.com/mediocre/image/upload/v1463770987/poaddeitz7s97sz47s7z.jpg)', function(err, html) {
-            assert.equal(html, '<p><a href="https://res.cloudinary.com/mediocre/image/upload/v1463770987/poaddeitz7s97sz47s7z.jpg">Fold out back</a></p>');
+        const image = 'https://res.cloudinary.com/mediocre/image/upload/v1463770987/poaddeitz7s97sz47s7z.jpg';
+
+        mehdown.render(`[Fold out back](${image})`, function(err, html) {
+            assert.equal(html, `<p><a href="${image}">Fold out back</a></p>`);
             done();
         });
     });

--- a/test/plugins/images.js
+++ b/test/plugins/images.js
@@ -74,4 +74,14 @@ describe('images', function() {
             done();
         });
     });
+
+    it('should render images linked to other urls with markdown', function(done) {
+        const otherUrl = 'http://www.example.com';
+        const image = 'https://www.images.com/someImage.jpg';
+
+        mehdown.render(`[${image}](${otherUrl})`, function(err, html) {
+            assert.equal(html, `<p><a href="${otherUrl}/" target="_blank"><img src="${image}" /></a></p>`);
+            done();
+        });
+    });
 });


### PR DESCRIPTION
This PR wraps images with anchor tags that are pointed directly to the images' source. There shouldn't be any change in behavior to images that are already linked in mehdown.

This way, clicking on an image in the meh forums will link a user to the image's source at full-size.

This is related to https://github.com/mediocre/mehdown/issues/23.