### PR TITLE
Search Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The Markdown parser used on the forums at meh.com.
 - `/giphy text` - Post a random GIF
 - `/image text` - Post a random image
 - `/roll notation or --help` - Roll the dice
+- `/search text` - Find past meh deals
 - `/shrug` - ¯\\\_(ツ)\_/¯
 - `/woot text` - Search for deals on woot.com
 - `/youtube text` - Post a random YouTube video

--- a/lib/index.js
+++ b/lib/index.js
@@ -521,6 +521,50 @@ const commands = {
 
         callback(null, textify.rot13(args));
     },
+    search: function(args, callback) {
+        // This command requires arguments.
+        if (!args) {
+            return callback();
+        }
+
+        const orig = args;
+        var showall = orig.toString().endsWith('--all');
+        args = args.replace('--all','').trim();
+
+        var limit = 10;
+        if (showall) {
+                limit = 100;
+        }
+        request.get(`http://api.mehstalker.com/read?search=${args}&limit=${limit}`, { json: true }, function(err, res, events) {
+            if (err || res.statusCode !== 200) {
+                return callback();
+            }
+
+            if (!events || !Array.isArray(events) || !events.length) {
+                return callback();
+            }
+            var offers = [];
+
+            var _markdown = `/search ${orig}\n`;
+            var numresults = 0;
+            var urls = '';
+            events.forEach(e => {
+                e.Offers.forEach(o => {
+                        numresults++;
+                        var price = '$' + o.SalePrice.toString().replace('-','-$');
+                        _markdown += `\n\n[${o.Title}][${numresults}] for ${price} - Sold Approx ${o.Sold} on ${o.SaleDate}\n`;
+                        urls += `\n[${numresults}]: ${o.Url.split('?')[0]}`;
+                });
+            });
+
+                _markdown += urls;
+                if (numresults === 10 && !showall) {
+                        _markdown += `\n\nExceeded max # of results (10) - Try refining your search or add the \`-all\` option.`;
+                }
+
+            callback(null, _markdown);
+        });
+    },
     shrug: function(args, callback) {
         callback(null, '¯\\\\\\\_(ツ)\\\_/¯');
     },

--- a/package.json
+++ b/package.json
@@ -29,5 +29,5 @@
     "scripts": {
         "test": "mocha --reporter spec test/*"
     },
-    "version": "2.23.0"
+    "version": "2.24.0"
 }

--- a/test/index.js
+++ b/test/index.js
@@ -433,6 +433,31 @@ describe('commands', function() {
         });
     });
 
+    describe('/search', function() {
+        this.timeout(30000);
+
+            it('/search {query}', function(done) {
+                request.get(`http://api.mehstalker.com/read?limit=1`, { json: true }, function(err, res, events) {
+                    var query = events[0].Offers[0].Title.split(' ')[0].toLowerCase();
+
+                    mehdown.render(`/search ${query}`, function(err, html) {
+                        assert.notEqual(html, `<p>/search ${query}</p>`);
+                        assert(html.includes('Approx'));
+                        done();
+                    });
+                });
+          });
+
+            it('/search fuk --all', function(done) {
+                    mehdown.render(`/search fuk --all`, function(err, html) {
+                        assert.notEqual(html, `<p>/search fuk --all</p>`);
+                        assert(html.includes('Approx'));
+                        assert(!html.includes('Exceeded'));
+                        done();
+                    });
+          });
+    });
+
     describe('/shrug', function() {
         it('/shrug', function(done) {
             mehdown.render('/shrug', function(err, html) {


### PR DESCRIPTION
Adding a /search command which queries a simple API from mehstalker to retrieve historical sales

By default, only returns the most recent 10 items
Allows --all option to show all results instead of past 10

If having /search is an issue if it's used on sites like checkout.org, command could be renamed