### PR TITLE
Added wootstalker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The Markdown parser used on the forums at meh.com.
 - `/reverse text` - txet esreveR
 - `/roll notation or --help` - Roll the dice
 - `/shrug` - ¯\\\_(ツ)\_/¯
-- `/wootstalker url` - Retrieve and display woot.com sale details
+- `/wootstalker url` - Display woot.com deal details
 - `/youtube text` - Post a random YouTube video
 
 ## Supports a subset of BBCode tags

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The Markdown parser used on the forums at meh.com.
 - `/reverse text` - txet esreveR
 - `/roll notation or --help` - Roll the dice
 - `/shrug` - ¯\\\_(ツ)\_/¯
+- `/wootstalker url` - Retrieve and display woot.com sale details
 - `/youtube text` - Post a random YouTube video
 
 ## Supports a subset of BBCode tags

--- a/lib/index.js
+++ b/lib/index.js
@@ -423,6 +423,101 @@ const commands = {
         // https://xkcd.com/1638/
         callback(null, '¯\\\\\\_(ツ)\\_/¯');
     },
+    wootstalker: function(args, callback) {
+        // This command requires arguments.
+        if (!args) {
+            var error = '/wootstalker\nError: You must specify a site or url to complete the lookup:cry:';
+            return callback(null, error);
+        }
+
+	    //Remove secondary arguments and any pasted variables
+	    const search = args.split(' ')[0].split('?')[0];
+
+        if (args === '--help' || args === '-h') {
+            var help = 'Usage: /wootstalker site|url\n\n';
+            help += 'Show details of a sale from woot.com\n\n';
+            help += 'Examples:\n';
+            help += '  `/wootstalker home` shows the details for the current home.woot sale.\n';
+            help += '  `/wootstalker shirt` shows the details for the current shirt.woot sale.\n';
+            help += '  `/wootstalker https://sellout.woot.com/offers/cratpv3nt-4-a11` shows the details for the sale of the specified url.\n';
+
+            return callback(null, `/wootstalker ${args}\n${help}`);
+        }
+
+	
+	    if (search === 'woot' || search === 'home' || search === 'sport' || search === 'wine' || search === 'gourmet' || search === 'sellout' || search === 'electronics' || 
+
+search === 'computers' || search === 'tools' || search === 'shirt') {
+		    var issite = 1;
+	    }
+
+	    const regExp = /(https:\/\/(www|shirt|home|computers|electronics|wine|sellout|sport|tools|gourmet))\.woot.com\/(offers)\/([-\w]+)/;
+        var matches = search.match(regExp);
+
+        if (matches && matches[1] && matches[2] && matches[3] && matches[4]) {
+                var isurl = 1;
+        }
+
+	    //store original arguments
+        const orig = args;
+        var _markdown = `/wootstalker ${orig}\n`;
+
+        //Inject affiliate code into valid urls
+        if (isurl === 1) {
+            _markdown = _markdown.replace(orig, `[${orig}][2]`);
+            var affurl = `\n[2]: http://products.wootstalker.com?url=${orig}`;
+        }
+
+	    if (isurl === 1 || issite == 1) {
+            //Get details from api
+	        request.get(`https://api.wootstalker.com/read?search=${search}`, { json: true }, function(err, res, events) {
+
+                if (err || res.statusCode !== 200) {
+	                var error = _markdown + '\nError: Unable to contact WootStalker :cry:';
+                    return callback(null, error);
+                }
+
+                if (!events || !Array.isArray(events) || !events.length) {
+		            var error = _markdown + '\nI was unable to find details for the supplied deal :cry:';
+                    return callback(null, error);
+                }
+
+                var urls = '';
+                var numresults = 0;
+                var success = 0;
+                events.forEach(e => {
+                    if (e.Offers) {
+	                    e.Offers.forEach(o => {
+			                success = 1;
+        	                numresults++;
+                            var price = '$' + o.SalePrice.toString().replace('- ','- $');
+                            var url = 'https://products.wootstalker.com?url=' + o.Url.split('?')[0];
+	                        _markdown += `\n**[ ${o.Title} for ${price} (${o.Condition})][${numresults}]**\n`;
+	                        _markdown += `[![${o.Title}](${o.Image})](${url})\n`;
+
+	                        urls += `\n[${numresults}]: ${url}`;
+                        });
+                    }
+                });
+
+                _markdown += urls;
+
+                if (isurl === 1) {
+                        _markdown += affurl;
+                }
+
+                if (success == 1) {
+                    callback(null, _markdown);
+                } else {
+                    _markdown += `\nI was unable to find details for the supplied deal :cry:`;
+                    callback(null, _markdown);
+                }
+            });
+        } else {
+	        _markdown += `\nWootStalker lookup failed - invalid site or url entered :cry:`;
+            callback(null, _markdown);
+        }
+    },
     youtube: function(args, callback) {
         // This command requires arguments.
         if (!args) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -424,97 +424,88 @@ const commands = {
         callback(null, '¯\\\\\\_(ツ)\\_/¯');
     },
     wootstalker: function(args, callback) {
-        // This command requires arguments.
-        if (!args) {
-            var error = '/wootstalker\nError: You must specify a site or url to complete the lookup :cry:';
-            return callback(null, error);
-        }
-
-	    //Remove secondary arguments and any pasted variables
-	    const search = args.split(' ')[0].split('?')[0];
-
-        if (args === '--help' || args === '-h') {
+        if (!args || args === '--help' || args === '-h') {
             var help = 'Usage: /wootstalker site|url\n\n';
-            help += 'Show details of a sale from woot.com\n\n';
+            help += 'Show details of a deal from woot.com\n\n';
             help += 'Examples:\n';
-            help += '  `/wootstalker home` shows the details for the current home.woot sale.\n';
-            help += '  `/wootstalker shirt` shows the details for the current shirt.woot sale.\n';
-            help += '  `/wootstalker https://sellout.woot.com/offers/cratpv3nt-4-a11` shows the details for the sale of the specified url.\n';
+            help += '  `/wootstalker home` shows the details for the current home.woot.com deal.\n';
+            help += '  `/wootstalker shirt` shows the details for the current shirt.woot.com deal.\n';
+            help += '  `/wootstalker https://sellout.woot.com/offers/cratpv3nt-4-a11` shows the details for the deal of the specified URL.\n';
 
-            return callback(null, `/wootstalker ${args}\n${help}`);
+            return callback(null, `/wootstalker ${args || ''}\n${help}`);
         }
 
-	
-	    if (search === 'woot' || search === 'home' || search === 'sport' || search === 'wine' || search === 'gourmet' || search === 'sellout' || search === 'electronics' || 
+        // Remove secondary arguments and any pasted variables
+        const search = args.split(' ')[0].split('?')[0];
 
-search === 'computers' || search === 'tools' || search === 'shirt') {
-		    var issite = 1;
-	    }
+        if (['computers', 'electronics', 'gourmet', 'home', 'sellout', 'shirt', 'sport', 'tools', 'wine', 'woot'].includes(search.toLowerCase())) {
+            var isSite = true;
+        }
 
-	    const regExp = /(https:\/\/(www|shirt|home|computers|electronics|wine|sellout|sport|tools|gourmet))\.woot.com\/(offers)\/([-\w]+)/;
+        const regExp = /(https:\/\/(computers|electronics|gourmet|home|sellout|shirt|sport|tools|wine|woot|www))\.woot.com\/(offers)\/([-\w]+)/;
         var matches = search.match(regExp);
 
         if (matches && matches[1] && matches[2] && matches[3] && matches[4]) {
-                var isurl = 1;
+            var isUrl = true;
         }
 
-	    //store original arguments
+        // Store original arguments
         const orig = args;
         var _markdown = `/wootstalker ${orig}\n`;
 
-        //Inject affiliate code into valid urls
-        if (isurl === 1) {
+        // Inject affiliate code into valid URLs
+        if (isUrl) {
             _markdown = _markdown.replace(orig, `[${orig}][2]`);
             var affurl = `\n[2]: http://products.wootstalker.com?url=${orig}`;
         }
 
-	    if (isurl === 1 || issite == 1) {
-            //Get details from api
-	        request.get(`https://api.wootstalker.com/read?search=${search}`, { json: true }, function(err, res, events) {
-
+        if (isSite || isUrl) {
+            // Get details from API
+            request.get(`https://api.wootstalker.com/read?search=${search}`, { json: true }, function(err, res, events) {
                 if (err || res.statusCode !== 200) {
-	                var error = _markdown + '\nError: Unable to contact WootStalker :cry:';
-                    return callback(null, error);
+                    return callback(null, `${_markdown}\nError: Unable to contact WootStalker :cry:`);
                 }
 
                 if (!events || !Array.isArray(events) || !events.length) {
-		            var error = _markdown + '\nI was unable to find details for the supplied deal :cry:';
-                    return callback(null, error);
+                    return callback(null, `${_markdown}\nI was unable to find details for the supplied deal :cry:`);
                 }
 
                 var urls = '';
                 var numresults = 0;
-                var success = 0;
+                var success = false;
+
                 events.forEach(e => {
                     if (e.Offers) {
-	                    e.Offers.forEach(o => {
-			                success = 1;
-        	                numresults++;
-                            var price = '$' + o.SalePrice.toString().replace('- ','- $');
-                            var url = 'https://products.wootstalker.com?url=' + o.Url.split('?')[0];
-	                        _markdown += `\n**[ ${o.Title} for ${price} (${o.Condition})][${numresults}]**\n`;
-	                        _markdown += `[![${o.Title}](${o.Image})](${url})\n`;
+                        e.Offers.forEach(o => {
+                            success = true;
+                            numresults++;
 
-	                        urls += `\n[${numresults}]: ${url}`;
+                            var price = `$${o.SalePrice.toString().replace('- ','- $')}`;
+                            var url = `https://products.wootstalker.com?url=${o.Url.split('?')[0]}`;
+
+                            _markdown += `\n**[${o.Title} for ${price} (${o.Condition})][${numresults}]**\n`;
+                            _markdown += `[![${o.Title}](${o.Image})](${url})\n`;
+
+                            urls += `\n[${numresults}]: ${url}`;
                         });
                     }
                 });
 
                 _markdown += urls;
 
-                if (isurl === 1) {
-                        _markdown += affurl;
+                if (isUrl) {
+                    _markdown += affurl;
                 }
 
-                if (success == 1) {
-                    callback(null, _markdown);
-                } else {
-                    _markdown += `\nI was unable to find details for the supplied deal :cry:`;
-                    callback(null, _markdown);
+                if (!success) {
+                    _markdown += '\nI was unable to find details for the specified deal :cry:';
+                    return callback(null, _markdown);
                 }
+
+                callback(null, _markdown);
             });
         } else {
-	        _markdown += `\nWootStalker lookup failed - invalid site or url entered :cry:`;
+            _markdown += '\nWootStalker lookup failed - invalid site or URL entered :cry:';
             callback(null, _markdown);
         }
     },

--- a/lib/index.js
+++ b/lib/index.js
@@ -426,7 +426,7 @@ const commands = {
     wootstalker: function(args, callback) {
         // This command requires arguments.
         if (!args) {
-            var error = '/wootstalker\nError: You must specify a site or url to complete the lookup:cry:';
+            var error = '/wootstalker\nError: You must specify a site or url to complete the lookup :cry:';
             return callback(null, error);
         }
 

--- a/package.json
+++ b/package.json
@@ -33,5 +33,5 @@
         "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec test/* && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
         "test": "mocha --reporter spec test/*"
     },
-    "version": "2.36.1"
+    "version": "2.36.0"
 }

--- a/package.json
+++ b/package.json
@@ -33,5 +33,5 @@
         "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec test/* && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
         "test": "mocha --reporter spec test/*"
     },
-    "version": "2.35.1"
+    "version": "2.36.1"
 }

--- a/test/index.js
+++ b/test/index.js
@@ -116,6 +116,15 @@ describe('commands', function() {
         });
     });
 
+    describe('/concerned', function() {
+        it('/concerned', function(done) {
+            mehdown.render('/concerned', function(err, html) {
+                assert.equal(html, '<p>ಠ_ಠ</p>');
+                done();
+            });
+        });
+    });
+
     describe('/cowsay', function() {
         this.timeout(10000);
 
@@ -449,41 +458,34 @@ describe('commands', function() {
         });
     });
 
-    describe('/concerned', function() {
-        it('/concerned', function(done) {
-            mehdown.render('/concerned', function(err, html) {
-                assert.equal(html, '<p>ಠ_ಠ</p>');
-                done();
-            });
-        });
-    });
-
     describe('/wootstalker', function() {
         it('/wootstalker', function(done) {
             mehdown.render('/wootstalker', function(err, html) {
                 assert.notEqual(html, '<p>/wootstalker</p>');
-                assert(html.includes('You must specify a site or url'));
+                assert(html.includes('Usage: /wootstalker site|url'));
                 done();
             });
-            });
+        });
 
         it('/wootstalker home', function(done) {
             mehdown.render('/wootstalker home', function(err, html) {
-                assert.notEqual(html, '<p>/wootstalker /home</p>');
+                assert.notEqual(html, '<p>/wootstalker home</p>');
                 assert(html.includes('home.woot.com'));
                 assert(html.includes('href'));
                 done();
             });
         });
+
         it('/wootstalker notarealsite', function(done) {
             mehdown.render('/wootstalker notarealsite', function(err, html) {
                 assert.notEqual(html, '<p>/wootstalker notarealsite</p>');
                 assert(html.includes('notarealsite'));
-                assert(html.includes('invalid site or url entered'));
+                assert(html.includes('invalid site or URL entered'));
                 assert(!html.includes('href'));
                 done();
             });
-         });
+        });
+
         it('/wootstalker https://electronics.woot.com/offers/parrot-quadcopter-swing-minidrone', function(done) {
             mehdown.render('/wootstalker https://electronics.woot.com/offers/parrot-quadcopter-swing-minidrone', function(err, html) {
                 assert.notEqual(html, '<p>/wootstalker https://electronics.woot.com/offers/parrot-quadcopter-swing-minidrone</p>');
@@ -492,9 +494,8 @@ describe('commands', function() {
                 done();
             });
         });
-
     });
-    
+
     describe('/youtube', function() {
         this.timeout(10000);
 

--- a/test/index.js
+++ b/test/index.js
@@ -458,6 +458,43 @@ describe('commands', function() {
         });
     });
 
+    describe('/wootstalker', function() {
+        it('/wootstalker', function(done) {
+            mehdown.render('/wootstalker', function(err, html) {
+                assert.notEqual(html, '<p>/wootstalker</p>');
+                assert(html.includes('You must specify a site or url'));
+                done();
+            });
+            });
+
+        it('/wootstalker home', function(done) {
+            mehdown.render('/wootstalker home', function(err, html) {
+                assert.notEqual(html, '<p>/wootstalker /home</p>');
+                assert(html.includes('home.woot.com'));
+                assert(html.includes('href'));
+                done();
+            });
+        });
+        it('/wootstalker notarealsite', function(done) {
+            mehdown.render('/wootstalker notarealsite', function(err, html) {
+                assert.notEqual(html, '<p>/wootstalker notarealsite</p>');
+                assert(html.includes('notarealsite'));
+                assert(html.includes('invalid site or url entered'));
+                assert(!html.includes('href'));
+                done();
+            });
+         });
+        it('/wootstalker https://electronics.woot.com/offers/parrot-quadcopter-swing-minidrone', function(done) {
+            mehdown.render('/wootstalker https://electronics.woot.com/offers/parrot-quadcopter-swing-minidrone', function(err, html) {
+                assert.notEqual(html, '<p>/wootstalker https://electronics.woot.com/offers/parrot-quadcopter-swing-minidrone</p>');
+                assert(html.includes('Parrot Quadcopter Swing Minidrone'));
+                assert(html.includes('href'));
+                done();
+            });
+        });
+
+    });
+    
     describe('/youtube', function() {
         this.timeout(10000);
 


### PR DESCRIPTION
Added /wootstalker command to retrieve sale details for woot.com sales
Supports site type (woot/home/sport etc) as an argument
Supports sale url (https://home.woot.com/offers/philips-norelco-multigroom-trimmer-with-attachments-3) as an arguement
Injects wootstalker affiliate url into links
Data retrieval is handled by WootStalker.com

Updated version/readme/tests
