### PR TITLE
/define patches

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -198,7 +198,7 @@ const commands = {
             });
 
             async.retry(function(callback) {
-                dict.definitions(args).then(function(res) {
+                dict.definitions(encodeURIComponent(args)).then(function(res) {
                     return callback(null, res);
                 }, function(err) {
                     callback(err);
@@ -212,15 +212,19 @@ const commands = {
                     return callback(null, _markdown);
                 }
 
+                var moredefs = 0;
                 res.results.forEach(r => {
                     r.lexicalEntries.forEach(le => {
+                        var newcategory = 1;
                         _markdown += `\n***${le.lexicalCategory.toUpperCase()}***\n`;
 
                         le.entries.forEach(e => {
                             // Only use the first homograph
-                            if (Number(e.homographNumber) >= 200) {
+                            if (Number(e.homographNumber) >= 200 && newcategory === 0) {
+                                moredefs = 1;
                                 return;
                             }
+                            newcategory = 0;
 
                             e.senses.forEach((s, i) => {
                                 s.definitions.forEach(d => {
@@ -238,6 +242,10 @@ const commands = {
                         });
                     });
                 });
+                
+                if (moredefs === 1) {
+                    _markdown += `\n\n More definitions available via [url=https://en.oxforddictionaries.com/definition/${encodeURIComponent(args)}]Oxford Dictionary[/url]\n`;
+                }
 
                 callback(null, _markdown);
             });

--- a/lib/index.js
+++ b/lib/index.js
@@ -212,10 +212,12 @@ const commands = {
                     return callback(null, _markdown);
                 }
 
+                //trigger link to oxford if throttle triggered
                 var moredefs = 0;
                 res.results.forEach(r => {
                     r.lexicalEntries.forEach(le => {
                         var newcategory = 1;
+                        var defentries = 0;
                         _markdown += `\n***${le.lexicalCategory.toUpperCase()}***\n`;
 
                         le.entries.forEach(e => {
@@ -224,16 +226,26 @@ const commands = {
                                 moredefs = 1;
                                 return;
                             }
+                            //used to ensure at least one definition per category is displayed
                             newcategory = 0;
 
-                            e.senses.forEach((s, i) => {
+                            e.senses.forEach((s) => {
                                 s.definitions.forEach(d => {
-                                    _markdown += `\n- **${i + 1}** ${d}  \n`;
+                                    defentries++;
+                                    //swap list types to ensure proper spacing between definitions
+                                    if (defentries % 2 === 1) {
+                                        _markdown += `- **${defentries}.** ${d}  \n`;
+                                    } else {
+                                        _markdown += `+ **${defentries}.** ${d}  \n`;
+                                    }
 
                                     if (s.subsenses) {
                                         s.subsenses.forEach((ss, j) => {
                                             ss.definitions.forEach(d => {
-                                                _markdown += `  - **${i + 1}.${j + 1}** ${d}\n`;
+                                                if (j <= 4) {
+                                                    _markdown += `  + **${defentries}.${j + 1}** ${d}\n`;
+                                                    moredefs = 1;
+                                                }
                                             });
                                         });
                                     }
@@ -242,7 +254,7 @@ const commands = {
                         });
                     });
                 });
-                
+
                 if (moredefs === 1) {
                     _markdown += `\n\n More definitions available via [url=https://en.oxforddictionaries.com/definition/${encodeURIComponent(args)}]Oxford Dictionary[/url]\n`;
                 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -224,12 +224,12 @@ const commands = {
 
                             e.senses.forEach((s, i) => {
                                 s.definitions.forEach(d => {
-                                    _markdown += `\n ${i + 1}. ${d}  \n`;
+                                    _markdown += `\n- **${i + 1}** ${d}  \n`;
 
                                     if (s.subsenses) {
                                         s.subsenses.forEach((ss, j) => {
                                             ss.definitions.forEach(d => {
-                                                _markdown += `  ${i + 1}.${j + 1} ${d}\n`;
+                                                _markdown += `  - **${i + 1}.${j + 1}** ${d}\n`;
                                             });
                                         });
                                     }

--- a/package.json
+++ b/package.json
@@ -36,5 +36,5 @@
         "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec test/* && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
         "test": "mocha --reporter spec test/*"
     },
-    "version": "2.38.0"
+    "version": "2.39.0"
 }

--- a/test/index.js
+++ b/test/index.js
@@ -214,12 +214,13 @@ describe('commands', function() {
                     done();
                 });
             });
-            
+
             it('/define -h', function(done) {
                 mehdown.render('/define -h', function(err, html) {
                     assert.notEqual(html, '<p>/define</p>');
                     assert(html.includes('Usage: /define word'));
                     assert(!html.includes('Error'));
+                    assert(!html.includes('Something went terribly wrong'));
                     done();
                 });
             });
@@ -229,6 +230,7 @@ describe('commands', function() {
                     assert.notEqual(html, '<p>/define meh</p>');
                     assert(html.includes('expressing a lack of interest or enthusiasm'));
                     assert(!html.includes('Error'));
+                    assert(!html.includes('Something went terribly wrong'));
                     done();
                 });
             });
@@ -238,6 +240,17 @@ describe('commands', function() {
                     assert.notEqual(html, '<p>/define test</p>');
                     assert(html.includes('a procedure intended to establish the quality, performance, or reliability of something, especially before it is taken into widespread use'));
                     assert(!html.includes('Error'));
+                    assert(!html.includes('Something went terribly wrong'));
+                    done();
+                });
+            });
+
+            it('/define hot dog', function(done) {
+                mehdown.render('/define hot dog', function(err, html) {
+                    assert.notEqual(html, '<p>/define test</p>');
+                    assert(html.includes('a frankfurter, especially one served hot in a long, soft roll and topped with various condiments'));
+                    assert(!html.includes('Error'));
+                    assert(!html.includes('Something went terribly wrong'));
                     done();
                 });
             });
@@ -246,6 +259,7 @@ describe('commands', function() {
                 mehdown.render('/define thisisnotarealword', function(err, html) {
                     assert.notEqual(html, '<p>/define thisisnotarealword</p>');
                     assert(html.includes('No exact matches found for the specified word.'));
+                    assert(!html.includes('Something went terribly wrong'));
                     done();
                 });
             });


### PR DESCRIPTION
Updated throttling. 
Ensure that at least 1 definition from each word type (verb, noun etc) is displayed.
Alter list types between + and - to ensure proper spacing.
Always increment main definition and only reset it upon new word type (verb, noun etc)
If throttling happens, link oxford dictionary for full reference