### PR TITLE
Header id permalinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.53.0] - 2023-03-06
+### Changed
+- Added `permalinkHeaders` HTML helper
+
 ## [2.52.0] - 2022-04-25
 ### Changed
 - Updated the `markdown-it` module to v13.0.0

--- a/lib/index.js
+++ b/lib/index.js
@@ -542,6 +542,9 @@ exports.html = {
     getElementsByTagName: function(html, tag) {
         return html.match(new RegExp('<' + tag + '[^>]*>', 'gi'));
     },
+    permalinkHeaders: function(html) {
+        return html.replace(/(<h(\d)\s+id="([^"]+")>.+?)(<\/h\2>)/gs,'$1<a class="permalink" href="#$3" title="Link to this section"><i class="fa fa-external-link"></i></a>$4');
+    },
     removeAttribute: function(html, attribute) {
         if (!html) {
             return;

--- a/lib/index.js
+++ b/lib/index.js
@@ -543,7 +543,8 @@ exports.html = {
         return html.match(new RegExp('<' + tag + '[^>]*>', 'gi'));
     },
     permalinkHeaders: function(html) {
-        return html.replace(/(<h(\d)\s+id="([^"]+")>.+?)(<\/h\2>)/gs,'$1<a class="permalink" href="#$3" title="Link to this section"><i class="fa fa-external-link"></i></a>$4');
+        // $0 - whole match, $1 - opening tag and content, $2 - opening tag name (to match the end tag), $3 - value of id attr, $4 - closing tag
+        return html.replace(/(<(h\d)\s+id="([^"]+")>.+?)(<\/\2>)/gs,'$1<a class="permalink" href="#$3" title="Link to this section"><i class="fa fa-external-link"></i></a>$4');
     },
     removeAttribute: function(html, attribute) {
         if (!html) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -542,9 +542,9 @@ exports.html = {
     getElementsByTagName: function(html, tag) {
         return html.match(new RegExp('<' + tag + '[^>]*>', 'gi'));
     },
-    permalinkHeaders: function(html) {
+    permalinkHeaders: function(html, icon = 'fa-bookmark') {
         // $0 - whole match, $1 - opening tag and content, $2 - opening tag name (to match the end tag), $3 - value of id attr, $4 - closing tag
-        return html.replace(/(<(h\d)\s+id="([^"]+")>.+?)(<\/\2>)/gs,'$1<a class="permalink" href="#$3" title="Link to this section"><i class="fa fa-external-link"></i></a>$4');
+        return html.replace(/(<(h\d)\s+id="([^"]+")>.+?)(<\/\2>)/gs,`$1<a class="permalink" href="#$3" title="Link to this section"><i class="fa ${icon}"></i></a>$4`);
     },
     removeAttribute: function(html, attribute) {
         if (!html) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -544,7 +544,7 @@ exports.html = {
     },
     permalinkHeaders: function(html, icon = 'fa-bookmark') {
         // $0 - whole match, $1 - opening tag and content, $2 - opening tag name (to match the end tag), $3 - value of id attr, $4 - closing tag
-        return html.replace(/(<(h\d)\s+id="([^"]+")>.+?)(<\/\2>)/gs,`$1<a class="permalink" href="#$3" title="Link to this section"><i class="fa ${icon}"></i></a>$4`);
+        return html.replace(/(<(h\d)\s+id="([^"]+)">.+?)(<\/\2>)/gs,`$1<a class="permalink" href="#$3" title="Link to this section"><i class="fa ${icon}"></i></a>$4`);
     },
     removeAttribute: function(html, attribute) {
         if (!html) {

--- a/package.json
+++ b/package.json
@@ -33,5 +33,5 @@
         "coveralls": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
         "test": "mocha --reporter spec test/*"
     },
-    "version": "2.52.0"
+    "version": "2.53.0"
 }

--- a/test/index.js
+++ b/test/index.js
@@ -797,7 +797,7 @@ describe('html', function() {
         });
     });
 
-    describe.only('permalinkHeaders', function() {
+    describe('permalinkHeaders', function() {
         it('no headers', function() {
             var html = '<div><span>hello</span> <span>world</span></div>';
             var html2 = mehdown.html.permalinkHeaders(html);

--- a/test/index.js
+++ b/test/index.js
@@ -797,6 +797,38 @@ describe('html', function() {
         });
     });
 
+    describe.only('permalinkHeaders', function() {
+        it('no headers', function() {
+            var html = '<div><span>hello</span> <span>world</span></div>';
+            var html2 = mehdown.html.permalinkHeaders(html);
+            assert.strictEqual(html, html2);
+        });
+
+        it('one header without id', function() {
+            var html = '<div><h1>hello world</h1><p>header</p></div>';
+            var html2 = mehdown.html.permalinkHeaders(html);
+            assert.strictEqual(html, html2);
+        });
+
+        it('one header', function() {
+            var html = '<div><h1 id="one">hello world</h1><p>header</p></div>';
+            html = mehdown.html.permalinkHeaders(html);
+            assert.strictEqual(html, '<div><h1 id="one">hello world<a class="permalink" href="#one" title="Link to this section"><i class="fa fa-bookmark"></i></a></h1><p>header</p></div>');
+        });
+
+        it('two headers', function() {
+            var html = '<div><h1 id="one">hello</h1><h2 id="two">world</h2><p>header</p></div>';
+            html = mehdown.html.permalinkHeaders(html);
+            assert.strictEqual(html, '<div><h1 id="one">hello<a class="permalink" href="#one" title="Link to this section"><i class="fa fa-bookmark"></i></a></h1><h2 id="two">world<a class="permalink" href="#two" title="Link to this section"><i class="fa fa-bookmark"></i></a></h2><p>header</p></div>');
+        });
+
+        it('custom icon', function() {
+            var html = '<div><h1 id="one">hello world</h1><p>header</p></div>';
+            html = mehdown.html.permalinkHeaders(html, 'fa-link');
+            assert.strictEqual(html, '<div><h1 id="one">hello world<a class="permalink" href="#one" title="Link to this section"><i class="fa fa-link"></i></a></h1><p>header</p></div>');
+        });
+    });
+
     describe('removeAttribute', function() {
         it('removeAttribute()', function() {
             assert.strictEqual(mehdown.html.removeAttribute(), undefined);


### PR DESCRIPTION
Add a `permalinkHeaders` html helper method to add permalink markup to headers with ids. This is intended to be used with the styles in mediocre-sdk forums. This step is entirely optional and will not be automatically applied or change the html we generate. This is in the same vein as `convertToLazyLoadedImages`.