### PR TITLE
Use media.stores.com custom domain for CDN delivery

### DIFF
--- a/test/plugins/images.js
+++ b/test/plugins/images.js
@@ -48,7 +48,7 @@ test('images', { concurrency: true }, async (t) => {
     });
 
     t.test('.webp', async () => {
-        const html = await render('https://d2b8wt72ktn9a2.cloudfront.net/mediocre/image/upload/v1741576249/pav6x1rkkve9imwcvybe.png');
-        assert.strictEqual(html, '<p><img src="https://d2b8wt72ktn9a2.cloudfront.net/mediocre/image/upload/v1741576249/pav6x1rkkve9imwcvybe.png" /></p>');
+        const html = await render('https://media.stores.com/mediocre/image/upload/v1741576249/pav6x1rkkve9imwcvybe.png');
+        assert.strictEqual(html, '<p><img src="https://media.stores.com/mediocre/image/upload/v1741576249/pav6x1rkkve9imwcvybe.png" /></p>');
     });
 });


### PR DESCRIPTION
Replaces the CloudFront distribution's default domain with its custom domain alias for content delivery.

`d2b8wt72ktn9a2.cloudfront.net` → `media.stores.com`

Same CloudFront distribution, same content — `media.stores.com` is now configured as a custom domain on top of it. See the `runbook-creating-a-media-url-for-content-delivery` forum topic for background.
